### PR TITLE
Fix bug to yield correct iterations in equivalence checker

### DIFF
--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -116,7 +116,10 @@ def find_counter_examples(
     simulator = AerSimulator(method="statevector")
 
     total_iterations = 0
+    break_loop = False
     for iterations in reversed(range(1, start_iterations + 1)):
+        if break_loop:
+            break
         total_iterations += iterations
         oracle = PhaseOracle(miter)
 
@@ -150,6 +153,7 @@ def find_counter_examples(
                     for t in range(len(found_counter_examples_list))
                 }
                 found_counter_examples = list(found_counter_examples_dict.keys())
+                break_loop = True
                 break
 
             diff = counts_list[i] - counts_list[i + 1]
@@ -160,6 +164,7 @@ def find_counter_examples(
                     for t in range(len(found_counter_examples_list))
                 }
                 found_counter_examples = list(found_counter_examples_dict.keys())
+                break_loop = True
                 break
 
     if counter_examples is None:

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -241,15 +241,15 @@ def verify_counter_examples(result_list: list[str], miter: str) -> bool:
     print("verify_solution")
     print("miter: ", miter)
     print("result_list: ", result_list)
+    # Map 'a' to 'z' to bits
+    var_names = list(string.ascii_lowercase[: len(result_list[0])])
+    # Translate to Python logical syntax
+    python_expr = miter.replace("~", "not ").replace("&", " and ").replace("|", " or ")
+
     invalid_res = False
     for result in result_list:
         print("verifying ", result)
-        # Map 'a' to 'z' to bits
-        var_names = list(string.ascii_lowercase[: len(result)])
         variables = {name: bool(int(value)) for name, value in zip(var_names, reversed(result))}
-
-        # Translate to Python logical syntax
-        python_expr = miter.replace("~", "not ").replace("&", " and ").replace("|", " or ")
         res = eval(python_expr, {"__builtins__": None}, variables)
 
         if not res:

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -140,15 +140,10 @@ def find_counter_examples(
         counts_list = [count for _, count in sorted_counts]
 
         for i in range(int(total_num_combinations * 0.5)):
-            if (i + 1) == len(counts_list):
-                found_counter_examples = [key for key, _ in sorted_counts]
-                if verify_counter_examples(found_counter_examples, miter):
-                    break
-                found_counter_examples = []
-            diff = counts_list[i] - counts_list[i + 1]
-            if diff > counts_list[i] * delta:
-                found_counter_examples = [key for key, _ in sorted_counts[: i + 1]]
-                if verify_counter_examples(found_counter_examples, miter):
+            if (i + 1) == len(counts_list) or ((counts_list[i] - counts_list[i + 1]) > (counts_list[i] * delta)):
+                potential_counter_examples = [key for key, _ in sorted_counts[: i + 1]]
+                if verify_counter_examples(potential_counter_examples, miter):
+                    found_counter_examples = potential_counter_examples
                     break
                 found_counter_examples = []
         if found_counter_examples:

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -142,12 +142,15 @@ def find_counter_examples(
         for i in range(int(total_num_combinations * 0.5)):
             if (i + 1) == len(counts_list):
                 found_counter_examples = [key for key, _ in sorted_counts]
-                break
+                if verify_counter_examples(found_counter_examples, miter):
+                    break
+                found_counter_examples = []
             diff = counts_list[i] - counts_list[i + 1]
             if diff > counts_list[i] * delta:
                 found_counter_examples = [key for key, _ in sorted_counts[: i + 1]]
                 if verify_counter_examples(found_counter_examples, miter):
                     break
+                found_counter_examples = []
         if found_counter_examples:
             break
 

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -251,7 +251,6 @@ def verify_counter_examples(result_list: list[str], miter: str) -> bool:
         print("verifying ", result)
         variables = {name: bool(int(value)) for name, value in zip(var_names, reversed(result))}
         res = eval(python_expr, {"__builtins__": None}, variables)
-
         if not res:
             invalid_res = True
             print(f"{result} is not a counter example.")

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -210,8 +210,8 @@ def try_parameter_combinations(
                     results.append(result)
                 if None in results:
                     row.append("-")
-                    raise RuntimeWarning
-                row.append(float(np.mean(np.asarray(results))))
+                else:
+                    row.append(float(np.mean(np.asarray(results))))
             data.loc[i] = row
             i += 1
 

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -116,7 +116,6 @@ def find_counter_examples(
     simulator = AerSimulator(method="statevector")
 
     total_iterations = 0
-    found_counter_examples = []
     oracle = PhaseOracle(miter)
     operator = GroverOperator(oracle).decompose()
 
@@ -147,7 +146,7 @@ def find_counter_examples(
                 break
         if potential_counter_examples:
             break
-    
+
     # Perform the check only if the potential counter examples are not empty
     if potential_counter_examples:
         # Check which of the two separated groups of counter examples are the real ones
@@ -242,7 +241,7 @@ def verify_counter_examples(result_list: list[str], miter: str) -> bool:
     var_names = list(string.ascii_lowercase[: len(result_list[0])])
     # Translate to Python logical syntax
     python_expr = miter.replace("~", "not ").replace("&", " and ").replace("|", " or ")
-    #pick first found element
+    # pick first found element
     first_result = result_list[0]
 
     variables = {name: bool(int(value)) for name, value in zip(var_names, reversed(first_result))}
@@ -250,19 +249,14 @@ def verify_counter_examples(result_list: list[str], miter: str) -> bool:
     if not res:
         print("Need to swtich groups")
         real_counter_examples = [format(i, f"0{len(result_list[0])}b") for i in range(2 ** len(result_list[0]))]
-        real_counter_examples = [i for i in real_counter_examples if not i in result_list]
-        return real_counter_examples
+        return [i for i in real_counter_examples if i not in result_list]
     return result_list
 
 
 num_bits = 6
 num_counter_examples = 57
-res_string, counter_examples = create_condition_string(
-    num_bits=num_bits, num_counter_examples=num_counter_examples
-)
+res_string, counter_examples = create_condition_string(num_bits=num_bits, num_counter_examples=num_counter_examples)
 
 shots = 512
 delta = 0.7
-found_counter_examples = find_counter_examples(
-    miter=res_string, num_bits=num_bits, shots=shots, delta=delta
-)
+found_counter_examples = find_counter_examples(miter=res_string, num_bits=num_bits, shots=shots, delta=delta)

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -122,9 +122,9 @@ def find_counter_examples(
         total_iterations += iterations
         oracle = PhaseOracle(miter)
         operator = GroverOperator(oracle).decompose()
-        
+
         num_bits = operator.num_qubits
-        total_num_combinations = 2 ** num_bits
+        total_num_combinations = 2**num_bits
 
         qc = QuantumCircuit(num_bits)
         qc.h(range(num_bits))
@@ -145,7 +145,7 @@ def find_counter_examples(
                 break
             diff = counts_list[i] - counts_list[i + 1]
             if diff > counts_list[i] * delta:
-                found_counter_examples = [key for key, _ in sorted_counts[:i + 1]]
+                found_counter_examples = [key for key, _ in sorted_counts[: i + 1]]
                 break
         if found_counter_examples:
             break

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -151,13 +151,13 @@ def find_counter_examples(
     if potential_counter_examples:
         # Check which of the two separated groups of counter examples are the real ones
         real_counter_examples = verify_counter_examples(potential_counter_examples, miter)
+
+        if counter_examples is None:
+            return real_counter_examples
     else:
         real_counter_examples = []
 
-    if counter_examples is None:
-        return real_counter_examples
-
-    if sorted(real_counter_examples) == sorted(counter_examples):
+    if sorted(real_counter_examples or []) == sorted(counter_examples or []):
         return total_iterations
 
     return None
@@ -223,7 +223,7 @@ def try_parameter_combinations(
     data.to_csv(path, index=False)
 
 
-def verify_counter_examples(result_list: list[str], miter: str) -> bool:
+def verify_counter_examples(result_list: list[str], miter: str) -> list[str]:
     """Verifies the counter examples found by Grover's algorithm.
 
     Parameters
@@ -247,16 +247,6 @@ def verify_counter_examples(result_list: list[str], miter: str) -> bool:
     variables = {name: bool(int(value)) for name, value in zip(var_names, reversed(first_result))}
     res = eval(python_expr, {"__builtins__": None}, variables)
     if not res:
-        print("Need to swtich groups")
         real_counter_examples = [format(i, f"0{len(result_list[0])}b") for i in range(2 ** len(result_list[0]))]
         return [i for i in real_counter_examples if i not in result_list]
     return result_list
-
-
-num_bits = 6
-num_counter_examples = 57
-res_string, counter_examples = create_condition_string(num_bits=num_bits, num_counter_examples=num_counter_examples)
-
-shots = 512
-delta = 0.7
-found_counter_examples = find_counter_examples(miter=res_string, num_bits=num_bits, shots=shots, delta=delta)

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -146,7 +146,8 @@ def find_counter_examples(
             diff = counts_list[i] - counts_list[i + 1]
             if diff > counts_list[i] * delta:
                 found_counter_examples = [key for key, _ in sorted_counts[: i + 1]]
-                break
+                if verify_counter_examples(found_counter_examples, miter):
+                    break
         if found_counter_examples:
             break
 
@@ -218,3 +219,37 @@ def try_parameter_combinations(
             i += 1
 
     data.to_csv(path, index=False)
+
+
+def verify_counter_examples(result_list: list[str], miter: str) -> bool:
+    """Verifies the counter examples found by Grover's algorithm.
+
+    Parameters
+    ----------
+    result_list : list[str]
+        List of counter examples
+    miter : str
+        Miter condition string
+    Returns
+    -------
+    bool
+        True if the counter examples are valid, False otherwise
+    """
+    print("verify_solution")
+    print("miter: ", miter)
+    print("result_list: ", result_list)
+    invalid_res = False
+    for result in result_list:
+        print("verifying ", result)
+        # Map 'a' to 'z' to bits
+        var_names = list(string.ascii_lowercase[: len(result)])
+        variables = {name: bool(int(value)) for name, value in zip(var_names, reversed(result))}
+
+        # Translate to Python logical syntax
+        python_expr = miter.replace("~", "not ").replace("&", " and ").replace("|", " or ")
+        res = eval(python_expr, {"__builtins__": None}, variables)
+
+        if not res:
+            invalid_res = True
+            print(f"{result} is not a counter example.")
+    return not invalid_res

--- a/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
+++ b/src/mqt/problemsolver/equivalence_checking/equivalence_checking.py
@@ -117,14 +117,14 @@ def find_counter_examples(
 
     total_iterations = 0
     found_counter_examples = []
+    oracle = PhaseOracle(miter)
+    operator = GroverOperator(oracle).decompose()
+
+    num_bits = operator.num_qubits
+    total_num_combinations = 2**num_bits
 
     for iterations in reversed(range(1, start_iterations + 1)):
         total_iterations += iterations
-        oracle = PhaseOracle(miter)
-        operator = GroverOperator(oracle).decompose()
-
-        num_bits = operator.num_qubits
-        total_num_combinations = 2**num_bits
 
         qc = QuantumCircuit(num_bits)
         qc.h(range(num_bits))

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -91,5 +91,20 @@ def test_find_counter_examples() -> None:
     predetermined_counter_examples.sort()
     assert found_counter_examples == predetermined_counter_examples
 
+    num_bits = 6
+    num_counter_examples = 0  # Test the equivalent case (using 0 counter examples)
+    res_string, predetermined_counter_examples = equivalence_checking.create_condition_string(
+        num_bits=num_bits, num_counter_examples=num_counter_examples
+    )
+    shots = 512
+    delta = 0.7
+    found_counter_examples = equivalence_checking.find_counter_examples(
+        miter=res_string, num_bits=num_bits, shots=shots, delta=delta
+    )
+    if isinstance(found_counter_examples, list):
+        found_counter_examples.sort()
+    predetermined_counter_examples.sort()
+    assert found_counter_examples == predetermined_counter_examples
+
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):
         equivalence_checking.find_counter_examples(miter=res_string, num_bits=5, shots=shots, delta=1.2)

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -53,7 +53,7 @@ def test_try_parameter_combinations(tmp_path: Path) -> None:
         (6, 0, False, None),
     ],
 )
-def test_determine_number_grover_iterations(
+def test_find_counter_examples(
     num_bits: int, num_counter_examples: int, get_counter_examples: bool, expected_num_iters: None | int
 ) -> None:
     """Test the function find_counter_examples."""

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -50,7 +50,7 @@ def test_try_parameter_combinations(tmp_path: Path) -> None:
 def test_find_counter_examples() -> None:
     """Test the function find_counter_examples."""
     num_bits = 6
-    num_counter_examples = 10
+    num_counter_examples = 3
     res_string, counter_examples = equivalence_checking.create_condition_string(
         num_bits=num_bits, num_counter_examples=num_counter_examples
     )
@@ -63,6 +63,12 @@ def test_find_counter_examples() -> None:
         found_counter_examples.sort()
     counter_examples.sort()
     assert found_counter_examples == counter_examples
+
+    number_iterations = equivalence_checking.find_counter_examples(
+        miter=res_string, num_bits=num_bits, shots=shots, delta=delta, counter_examples=counter_examples
+    )
+
+    assert number_iterations == 5
 
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):
         equivalence_checking.find_counter_examples(miter=res_string, num_bits=5, shots=shots, delta=1.2)

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -67,7 +67,7 @@ def test_find_counter_examples() -> None:
     number_iterations = equivalence_checking.find_counter_examples(
         miter=res_string, num_bits=num_bits, shots=shots, delta=delta, counter_examples=counter_examples
     )
-    
+
     # 5 iterations were determined by multiple experiments in the case of 6 bits and 3 counter examples
     assert number_iterations == 5
 

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
 
 import pytest
@@ -28,7 +27,6 @@ def test_create_condition_string() -> None:
         equivalence_checking.create_condition_string(num_bits=-5, num_counter_examples=-2)
 
 
-@pytest.mark.skipif(not importlib.util.find_spec("tweedledum"), reason="tweedledum is not installed")
 def test_try_parameter_combinations(tmp_path: Path) -> None:
     """Test the function try_parameter_combinations."""
     path_to_csv = tmp_path / "sub" / "test1.csv"
@@ -46,55 +44,40 @@ def test_try_parameter_combinations(tmp_path: Path) -> None:
     path_to_csv.parent.rmdir()
 
 
-@pytest.mark.skipif(not importlib.util.find_spec("tweedledum"), reason="tweedledum is not installed")
 @pytest.mark.parametrize(
-    ("num_bits", "num_counter_examples", "delta", "shots"),
+    ("num_bits", "num_counter_examples", "get_counter_examples", "expected_num_iters"),
     [
-        (6, 3, 0.7, 512),
-        (6, 32, 0.7, 512),
-        (6, 57, 0.7, 512),
-        (6, 0, 0.7, 512),
+        (6, 3, True, 5),
+        (6, 32, True, None),
+        (6, 57, False, None),
+        (6, 0, False, None),
     ],
 )
-def test_find_counter_examples(num_bits: int, num_counter_examples: int, delta: float, shots: int) -> None:
+def test_determine_number_grover_iterations(
+    num_bits: int, num_counter_examples: int, get_counter_examples: bool, expected_num_iters: None | int
+) -> None:
     """Test the function find_counter_examples."""
 
     res_string, predetermined_counter_examples = equivalence_checking.create_condition_string(
         num_bits=num_bits, num_counter_examples=num_counter_examples
     )
 
-    if num_counter_examples == 32:
-        found_counter_examples = equivalence_checking.find_counter_examples(
-            miter=res_string,
-            num_bits=num_bits,
-            shots=shots,
-            delta=delta,
-            predetermined_counter_examples=predetermined_counter_examples,
-        )
-        assert found_counter_examples is None
+    result = equivalence_checking.find_counter_examples(
+        miter=res_string,
+        num_bits=num_bits,
+        shots=512,
+        delta=0.7,
+        predetermined_counter_examples=predetermined_counter_examples if get_counter_examples else None,
+    )
 
+    if get_counter_examples:
+        assert result is expected_num_iters
     else:
-        found_counter_examples = equivalence_checking.find_counter_examples(
-            miter=res_string, num_bits=num_bits, shots=shots, delta=delta
-        )
+        assert isinstance(result, list)
+        assert result.sort() == predetermined_counter_examples.sort()
 
-        if isinstance(found_counter_examples, list):
-            found_counter_examples.sort()
-        predetermined_counter_examples.sort()
 
-        assert found_counter_examples == predetermined_counter_examples
-
-    if num_counter_examples == 3:
-        number_iterations = equivalence_checking.find_counter_examples(
-            miter=res_string,
-            num_bits=num_bits,
-            shots=shots,
-            delta=delta,
-            predetermined_counter_examples=predetermined_counter_examples,
-        )
-
-        # 5 iterations were determined by multiple experiments in the case of 6 bits and 3 counter examples
-        assert number_iterations == 5
-
+def test_faulty_delta_value() -> None:
+    """Test the function find_counter_examples with a faulty delta value."""
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):
-        equivalence_checking.find_counter_examples(miter=res_string, num_bits=5, shots=shots, delta=1.2)
+        equivalence_checking.find_counter_examples(miter="", num_bits=5, shots=512, delta=1.2)

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -67,7 +67,8 @@ def test_find_counter_examples() -> None:
     number_iterations = equivalence_checking.find_counter_examples(
         miter=res_string, num_bits=num_bits, shots=shots, delta=delta, counter_examples=counter_examples
     )
-
+    
+    # 5 iterations were determined by multiple experiments in the case of 6 bits and 3 counter examples
     assert number_iterations == 5
 
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -51,7 +51,7 @@ def test_find_counter_examples() -> None:
     """Test the function find_counter_examples."""
     num_bits = 6
     num_counter_examples = 3
-    res_string, counter_examples = equivalence_checking.create_condition_string(
+    res_string, predetermined_counter_examples = equivalence_checking.create_condition_string(
         num_bits=num_bits, num_counter_examples=num_counter_examples
     )
     shots = 512
@@ -61,20 +61,24 @@ def test_find_counter_examples() -> None:
     )
     if isinstance(found_counter_examples, list):
         found_counter_examples.sort()
-    counter_examples.sort()
-    assert found_counter_examples == counter_examples
+    predetermined_counter_examples.sort()
+    assert found_counter_examples == predetermined_counter_examples
 
     number_iterations = equivalence_checking.find_counter_examples(
-        miter=res_string, num_bits=num_bits, shots=shots, delta=delta, counter_examples=counter_examples
+        miter=res_string,
+        num_bits=num_bits,
+        shots=shots,
+        delta=delta,
+        predetermined_counter_examples=predetermined_counter_examples,
     )
 
     # 5 iterations were determined by multiple experiments in the case of 6 bits and 3 counter examples
     assert number_iterations == 5
 
-    # Test, if the correct group of states gets identified as counter examples
+    # Test, if the correct group of states gets identified as counter examples (using > 50 % counter examples)
     num_bits = 6
     num_counter_examples = 57
-    res_string, counter_examples = equivalence_checking.create_condition_string(
+    res_string, predetermined_counter_examples = equivalence_checking.create_condition_string(
         num_bits=num_bits, num_counter_examples=num_counter_examples
     )
     shots = 512
@@ -84,8 +88,8 @@ def test_find_counter_examples() -> None:
     )
     if isinstance(found_counter_examples, list):
         found_counter_examples.sort()
-    counter_examples.sort()
-    assert found_counter_examples == counter_examples
+    predetermined_counter_examples.sort()
+    assert found_counter_examples == predetermined_counter_examples
 
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):
         equivalence_checking.find_counter_examples(miter=res_string, num_bits=5, shots=shots, delta=1.2)

--- a/tests/test_equivalence_checking.py
+++ b/tests/test_equivalence_checking.py
@@ -71,5 +71,21 @@ def test_find_counter_examples() -> None:
     # 5 iterations were determined by multiple experiments in the case of 6 bits and 3 counter examples
     assert number_iterations == 5
 
+    # Test, if the correct group of states gets identified as counter examples
+    num_bits = 6
+    num_counter_examples = 57
+    res_string, counter_examples = equivalence_checking.create_condition_string(
+        num_bits=num_bits, num_counter_examples=num_counter_examples
+    )
+    shots = 512
+    delta = 0.7
+    found_counter_examples = equivalence_checking.find_counter_examples(
+        miter=res_string, num_bits=num_bits, shots=shots, delta=delta
+    )
+    if isinstance(found_counter_examples, list):
+        found_counter_examples.sort()
+    counter_examples.sort()
+    assert found_counter_examples == counter_examples
+
     with pytest.raises(ValueError, match="Invalid value for delta 1.2, which must be between 0 and 1."):
         equivalence_checking.find_counter_examples(miter=res_string, num_bits=5, shots=shots, delta=1.2)


### PR DESCRIPTION
Fixes a bug that did not break the loop over the iterations in the function ```find_counter_examples``` , leading to a maximum number of iterations for all cases. Tests were extended such that this case is now covered as well. Furthermore, the overall structure of the code was improved.