### PR TITLE
🔥 Drop support for x86 macOS systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [
-            ubuntu-24.04,
-            ubuntu-24.04-arm,
-            macos-14,
-            windows-2022,
-            windows-11-arm,
-          ]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2022]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
## Description

As `tket` has dropped support for x86 macOS systems (see the [release notes of v2.10.0](https://github.com/CQCL/tket/releases/tag/v2.10.0)), we are following suit. `mqt-problemsolver` will no longer be tested on such systems in the future. 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration matrix: swapped one macOS Intel runner for a Windows ARM runner while keeping broad Ubuntu, macOS, and Windows coverage to streamline CI maintenance without changing test scope or public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->