### PR TITLE
📝 Improve `pip install` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To support this endeavor, please consider:
 [PyPI](https://pypi.org/project/mqt.problemsolver/).
 
 ```console
-(.venv) $ pip install mqt.problemsolver
+uv pip install mqt.problemsolver
 ```
 
 **Detailed documentation and examples are available at


### PR DESCRIPTION
## Description

This PR improves the `pip install` command in the README by removing `(.venv) $`, ensuring that the command is actually copyable. 

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.